### PR TITLE
warnings + tolerance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,8 +25,8 @@ Imports:
     pbapply,
     chk (>= 0.8.1),
     rlang,
-    insight (>= 0.18.8),
-    marginaleffects (>= 0.8.1),
+    insight (>= 0.19.0),
+    marginaleffects (>= 0.9.0),
     mvnfast
 Suggests: 
     testthat (>= 3.0.0),

--- a/R/sim_ame.R
+++ b/R/sim_ame.R
@@ -302,7 +302,7 @@ attach_pred_data_to_fit <- function(fit, index.sub = NULL, is_fitlist = FALSE) {
     fit <- lapply(fit, attach_pred_data_to_fit, index.sub)
   }
   else {
-    data <- insight::get_data(fit)
+    data <- insight::get_data(fit, verbose = FALSE)
     weights <- insight::get_weights(fit, null_as_ones = TRUE)
     vars <- insight::find_predictors(fit, effects = "fixed", component = "all",
                                      flatten = TRUE)

--- a/tests/testthat/test-sim.R
+++ b/tests/testthat/test-sim.R
@@ -439,6 +439,7 @@ test_that("sim() works with estimatr::iv_robust()", {
 
 test_that("sim() works with fixest::feols()", {
   skip_if_not_installed("fixest")
+  fixest::setFixest_nthreads(1)
   mdata <- readRDS(test_path("fixtures", "mdata.rds"))
 
   fit <- fixest::feols(re78 ~ treat + age + educ + race + re74, data = mdata,
@@ -677,7 +678,7 @@ test_that("sim() works with rms::ols()", {
   expect_equal(colnames(s$sim.coefs),
                c("Intercept", "treat", "age", "age^2", "age^3", "educ", "race=hispan",
                  "race=white", "re74", "re74'"))
-  expect_equal(attr(s, "dist"), "t(569.230711076445)")
+  expect_true(grepl("t\\(569.230711", attr(s, "dist")))
 
   s <- sim(fit, n = 5, dist = "norm")
   expect_good_clarify_sim(s)

--- a/tests/testthat/test-sim_ame.R
+++ b/tests/testthat/test-sim_ame.R
@@ -560,6 +560,7 @@ test_that("sim_ame() works with estimatr::iv_robust()", {
 
 test_that("sim_ame() works with fixest::feols()", {
   mdata <- readRDS(test_path("fixtures", "mdata.rds"))
+  fixest::setFixest_nthreads(1)
 
   fit <- fixest::feols(re78 ~ treat + age + educ + race + re74, data = mdata,
                        weights = ~weights)
@@ -879,14 +880,14 @@ test_that("sim_ame() works with rms::ols()", {
   mdata <- readRDS(test_path("fixtures", "mdata.rds"))
 
   suppressMessages(library(rms))
-
+  
   dd <<- suppressWarnings(datadist(mdata))
   op <- options(datadist = "dd")
 
   fit <- ols(re78 ~ treat + pol(age, 3) +
                educ + catg(race) + rcs(re74, 4), data = mdata,
              penalty = 3)
-
+  
   s <- sim(fit, n = 5)
 
   e <- sim_ame(s, "treat", verbose = FALSE)


### PR DESCRIPTION
Once again, a release of `marginaleffects` will break one (1) of your tests. It's because you were comparing a t stat up to 10 significant digit tolerance, and a very small change in the numeric differentiation algorithm lead to an inconsequential change.

I'll do my best to avoid these changes in the future, but recommend setting `tolerance` in tests that rely on `marginaleffects`.

I also took the liberty to silence a bunch of warnings.